### PR TITLE
Prepare deploy to private registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - 0.6

--- a/README.markdown
+++ b/README.markdown
@@ -3,8 +3,6 @@ traverse
 
 Traverse and transform objects by visiting every node on a recursive walk.
 
-[![build status](https://secure.travis-ci.org/substack/js-traverse.png)](http://travis-ci.org/substack/js-traverse)
-
 examples
 ========
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name" : "@apiaryio/traverse",
-    "version" : "0.6.3",
+    "version" : "1.0.0",
     "description" : "traverse and transform objects by visiting every node on a recursive walk",
     "license" : "MIT",
     "engine" : { "node" : ">=0.6" },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "repository" : {
         "type" : "git",
-        "url" : "git://github.com/apiaryio/js-traverese.git"
+        "url" : "git://github.com/apiaryio/js-traverse.git"
     },
     "publishConfig": {
         "registry": "https://registry.apiary-internal.com"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-    "name" : "traverse",
+    "name" : "@apiaryio/traverse",
     "version" : "0.6.3",
     "description" : "traverse and transform objects by visiting every node on a recursive walk",
+    "license" : "MIT",
+    "engine" : { "node" : ">=0.6" },
     "main" : "index.js",
-    "bin" : {},
     "directories" : {
         "example" : "example",
         "test" : "test"
     },
-    "dependencies" : {},
     "devDependencies" : {
         "tap" : "~0.2.5"
     },
@@ -17,23 +17,9 @@
     },
     "repository" : {
         "type" : "git",
-        "url" : "git://github.com/substack/js-traverse.git"
+        "url" : "git://github.com/apiaryio/js-traverese.git"
     },
-    "homepage" : "https://github.com/substack/js-traverse",
-    "keywords" : [
-        "traverse",
-        "walk",
-        "recursive",
-        "map",
-        "forEach",
-        "deep",
-        "clone"
-    ],
-    "author" : {
-        "name" : "James Halliday",
-        "email" : "mail@substack.net",
-        "url" : "http://substack.net"
-    },
-    "license" : "MIT",
-    "engine" : { "node" : ">=0.6" }
+    "publishConfig": {
+        "registry": "https://registry.apiary-internal.com"
+    }
 }


### PR DESCRIPTION
Preparation for one time deploy to private registry

- removed unused `travis.yml`
- removed build badge inherited from original repository
- lets deploy it as 1.0.0
- removed unnecessary values from package.json